### PR TITLE
Allow .dsk as a file extension for floppies.

### DIFF
--- a/core/src/floppy_manager.rs
+++ b/core/src/floppy_manager.rs
@@ -86,7 +86,7 @@ impl FloppyManager {
             Err(_) => return Err(FloppyError::DirNotFound)
         };
 
-        let extensions = ["img", "ima"];
+        let extensions = ["img", "ima", "dsk"];
 
         // Clear and rebuild image lists.
         self.image_vec.clear();


### PR DESCRIPTION
Idk what your plans are for supporting file extensions for floppies (they aren't listed on [the wiki](https://github.com/dbalsom/martypc/wiki/MartyPC-User-Guide#floppy-disks), but the DOS disks I use have a ".dsk" extension.

Since there's really no standard extension for floppy images, I assume there's no harm done for adding extensions as needed (instead of having the user rename them and/or wonder "where's my floppy images" before they look at the source)?

Also, be warned... I may be opening a bunch of issues as I play with this (excellent!) emulator :). I'll make an effort to pace them out.