### PR TITLE
Add workflow files to enable GitHub Actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,8 @@ name: Linux
 
 on:
   push:
+    branches:
+      - version_0_2_0
   pull_request:
 
 env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,49 @@
+name: Linux
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: martypc
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: >-
+          sudo apt update && sudo apt install
+          libasound2-dev
+          libudev-dev
+
+      - name: Cargo build
+        run: cargo build -r --features ega
+
+      - name: Copy files into install dir
+        run: cp README.md target/release/martypc install
+
+      - name: Rename install directory
+        run: mv install martypc
+
+      - name: Create artifact directory
+        run: mkdir artifacts
+
+      # GitHub zips all artifacts, losing file permissions.
+      # We'll need to tar the directory in order to
+      # preserve the file permissions
+      - name: Create artifact from install directory
+        run: tar cvf artifacts/martypc.tar martypc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'martypc-linux-gha${{ github.run_number }}'
+          path: artifacts/martypc.tar

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,8 @@ name: macOS
 
 on:
   push:
+    branches:
+      - version_0_2_0
   pull_request:
 
 env:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,77 @@
+name: macOS
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  macos-arm:
+    name: martypc (arm)
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cargo build
+        run: cargo build -r --features ega
+
+      - name: Copy files into install dir
+        run: cp README.md target/release/martypc install
+
+      - name: Rename install directory
+        run: mv install martypc
+
+      - name: Create artifact directory
+        run: mkdir artifacts
+
+      # GitHub zips all artifacts, losing file permissions.
+      # We'll need to tar the directory in order to
+      # preserve the file permissions
+      - name: Create artifact from install directory
+        run: tar cvf artifacts/martypc.tar martypc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'martypc-${{ github.job }}-gha${{ github.run_number }}'
+          path: artifacts/martypc.tar
+
+  macos-x86:
+    name: martypc (x86)
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cargo build
+        run: cargo build -r --features ega
+
+      - name: Copy files into install dir
+        run: cp README.md target/release/martypc install
+
+      - name: Rename install directory
+        run: mv install martypc
+
+      - name: Create artifact directory
+        run: mkdir artifacts
+
+      # GitHub zips all artifacts, losing file permissions.
+      # We'll need to tar the directory in order to
+      # preserve the file permissions
+      - name: Create artifact from install directory
+        run: tar cvf artifacts/martypc.tar martypc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'martypc-${{ github.job }}-gha${{ github.run_number }}'
+          path: artifacts/martypc.tar

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,8 @@ name: Windows
 
 on:
   push:
+    branches:
+      - version_0_2_0
   pull_request:
 
 env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,52 @@
+name: Windows
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  msys2:
+    name: martypc
+    runs-on: windows-2022
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    strategy:
+      matrix:
+        environment:
+          - msystem: MINGW64
+            prefix: mingw-w64-x86_64
+    steps:
+      - name: Prepare MSYS2 environment
+        uses: msys2/setup-msys2@v2
+        with:
+          release: false
+          update: true
+          msystem: ${{ matrix.environment.msystem }}
+          pacboy: >-
+            rust:p
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cargo build
+        run: cargo build -r --features ega
+
+      - name: Copy files into install dir
+        run: cp README.md target/release/martypc install
+
+      - name: Rename install directory
+        run: mv install martypc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'martypc-windows-gha${{ github.run_number }}'
+          path: martypc


### PR DESCRIPTION
This PR adds basic workflow files to enable GHA for the following platforms:

* Windows x86_64 via msys2
* Linux x86_64
* macOS (arm and x86_64)
  * Separate jobs and artifacts are required because cargo can't build universal binaries

Each run will have a portable artifact produced in the form of a zip. 

The steps are essentially:
* Build martypc
* Copy binary to `install/`
* Rename `install/` to `martypc/`
* Create artifact from that directory

**Note:** The binaries are currently being built with the EGA feature (`cargo build -r --features ega`). If this becomes default in the future (or the build args change for any reason) the build command will need to be updated.

It would probably be more ideal to add a matrix to the workflow and produce multiple artifacts based on different build-time features.

**Also note:** GitHub only supports zip files as artifacts. Since zip does not maintain posix file permissions a tar file is first created on macOS and linux. That tar file is then zipped by GitHub and presented as the artifact.