### PR TITLE
Register unions

### DIFF
--- a/core/src/cpu_808x/addressing.rs
+++ b/core/src/cpu_808x/addressing.rs
@@ -166,32 +166,32 @@ impl Cpu {
 
         let (seg_val, seg, offset) = match mode {
             // All of this relies on 2's compliment arithmetic for signed displacements
-            AddressingMode::BxSi                => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(self.si)),
-            AddressingMode::BxDi                => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(self.di)),
+            AddressingMode::BxSi                => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(self.si)),
+            AddressingMode::BxDi                => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(self.di)),
             AddressingMode::BpSi                => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(self.si)),  // BP -> SS default seg
             AddressingMode::BpDi                => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(self.di)),  // BP -> SS default seg
             AddressingMode::Si                  => (segment_value_base_ds, segment_base_ds, self.si),
             AddressingMode::Di                  => (segment_value_base_ds, segment_base_ds, self.di),
             AddressingMode::Disp16(disp16)      => (segment_value_base_ds, segment_base_ds, disp16.get_u16()),
-            AddressingMode::Bx                  => (segment_value_base_ds, segment_base_ds, self.bx),
+            AddressingMode::Bx                  => (segment_value_base_ds, segment_base_ds, self.b.x()),
             
-            AddressingMode::BxSiDisp8(disp8)    => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(self.si.wrapping_add(disp8.get_u16()))),
-            AddressingMode::BxDiDisp8(disp8)    => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(self.di.wrapping_add(disp8.get_u16()))),
+            AddressingMode::BxSiDisp8(disp8)    => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(self.si.wrapping_add(disp8.get_u16()))),
+            AddressingMode::BxDiDisp8(disp8)    => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(self.di.wrapping_add(disp8.get_u16()))),
             AddressingMode::BpSiDisp8(disp8)    => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(self.si.wrapping_add(disp8.get_u16()))),  // BP -> SS default seg
             AddressingMode::BpDiDisp8(disp8)    => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(self.di.wrapping_add(disp8.get_u16()))),  // BP -> SS default seg
             AddressingMode::SiDisp8(disp8)      => (segment_value_base_ds, segment_base_ds, self.si.wrapping_add(disp8.get_u16())),
             AddressingMode::DiDisp8(disp8)      => (segment_value_base_ds, segment_base_ds, self.di.wrapping_add(disp8.get_u16())),
             AddressingMode::BpDisp8(disp8)      => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(disp8.get_u16())),    // BP -> SS default seg
-            AddressingMode::BxDisp8(disp8)      => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(disp8.get_u16())),
+            AddressingMode::BxDisp8(disp8)      => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(disp8.get_u16())),
             
-            AddressingMode::BxSiDisp16(disp16)  => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(self.si.wrapping_add(disp16.get_u16()))),
-            AddressingMode::BxDiDisp16(disp16)  => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(self.di.wrapping_add(disp16.get_u16()))),
+            AddressingMode::BxSiDisp16(disp16)  => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(self.si.wrapping_add(disp16.get_u16()))),
+            AddressingMode::BxDiDisp16(disp16)  => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(self.di.wrapping_add(disp16.get_u16()))),
             AddressingMode::BpSiDisp16(disp16)  => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(self.si.wrapping_add(disp16.get_u16()))), // BP -> SS default reg
             AddressingMode::BpDiDisp16(disp16)  => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(self.di.wrapping_add(disp16.get_u16()))), // BP -> SS default reg
             AddressingMode::SiDisp16(disp16)    => (segment_value_base_ds, segment_base_ds, self.si.wrapping_add(disp16.get_u16())),
             AddressingMode::DiDisp16(disp16)    => (segment_value_base_ds, segment_base_ds, self.di.wrapping_add(disp16.get_u16())),
             AddressingMode::BpDisp16(disp16)    => (segment_value_base_ss, segment_base_ss, self.bp.wrapping_add(disp16.get_u16())),   // BP -> SS default reg
-            AddressingMode::BxDisp16(disp16)    => (segment_value_base_ds, segment_base_ds, self.bx.wrapping_add(disp16.get_u16())),
+            AddressingMode::BxDisp16(disp16)    => (segment_value_base_ds, segment_base_ds, self.b.x().wrapping_add(disp16.get_u16())),
 
             // The instruction decoder should convert ModRM operands that specify Registers to Register type operands, so
             // in theory this shouldn't happen
@@ -292,14 +292,14 @@ impl Cpu {
                 Some(byte)
             }
             OperandType::Register8(reg8) => match reg8 {
-                Register8::AH => Some(self.ah),
-                Register8::AL => Some(self.al),
-                Register8::BH => Some(self.bh),
-                Register8::BL => Some(self.bl),
-                Register8::CH => Some(self.ch),
-                Register8::CL => Some(self.cl),
-                Register8::DH => Some(self.dh),
-                Register8::DL => Some(self.dl),
+                Register8::AH => Some(self.a.h()),
+                Register8::AL => Some(self.a.l()),
+                Register8::BH => Some(self.b.h()),
+                Register8::BL => Some(self.b.l()),
+                Register8::CH => Some(self.c.h()),
+                Register8::CL => Some(self.c.l()),
+                Register8::DH => Some(self.d.h()),
+                Register8::DL => Some(self.d.l()),
             }
             OperandType::AddressingMode(_mode) => {
                 // EA operand was already fetched into ea_opr. Return masked byte.
@@ -342,10 +342,10 @@ impl Cpu {
                 Some(word)
             }
             OperandType::Register16(reg16) => match reg16 {
-                Register16::AX => Some(self.ax),
-                Register16::CX => Some(self.cx),
-                Register16::DX => Some(self.dx),
-                Register16::BX => Some(self.bx),
+                Register16::AX => Some(self.a.x()),
+                Register16::CX => Some(self.c.x()),
+                Register16::DX => Some(self.d.x()),
+                Register16::BX => Some(self.b.x()),
                 Register16::SP => Some(self.sp),
                 Register16::BP => Some(self.bp),
                 Register16::SI => Some(self.si),

--- a/core/src/cpu_808x/alu.rs
+++ b/core/src/cpu_808x/alu.rs
@@ -223,7 +223,7 @@ impl Cpu {
     /// otherwise, the flags are set. The SF, ZF, AF, and PF flags are undefined.
     pub fn multiply_u8(&mut self, operand1: u8) {
         // 8 bit operand => 16 bit product
-        let product: u16 = self.al as u16 * operand1 as u16;
+        let product: u16 = self.a.l() as u16 * operand1 as u16;
 
         // Set carry and overflow if product wouldn't fit in u8
         if product & 0xFF00 == 0 {
@@ -244,7 +244,7 @@ impl Cpu {
     /// otherwise, the flags are set. The SF, ZF, AF, and PF flags are undefined.
     pub fn multiply_u16(&mut self, operand1: u16) {
         // 16 bit operand => 32bit product
-        let product: u32 = self.ax as u32 * operand1 as u32;
+        let product: u32 = self.a.x() as u32 * operand1 as u32;
 
         // Set carry and overflow if product wouldn't fit in u16
         if product & 0xFFFF0000 == 0 {
@@ -270,7 +270,7 @@ impl Cpu {
     /// The SF, ZF, AF, and PF flags are undefined.
     pub fn multiply_i8(&mut self, operand1: i8) {
         // 8 bit operand => 16 bit product
-        let product: i16 = (self.al as i8 as i16) * (operand1 as i16);
+        let product: i16 = (self.a.l() as i8 as i16) * (operand1 as i16);
 
         // Set carry and overflow if product wouldn't fit in i8
         if product < i8::MIN.into() || product > i8::MAX.into() {
@@ -292,7 +292,7 @@ impl Cpu {
     /// The SF, ZF, AF, and PF flags are undefined.
     pub fn multiply_i16(&mut self, operand1: i16) {
         // 16 bit operand => 32 bit product
-        let product: i32 = (self.ax as i16 as i32) * (operand1 as i32);
+        let product: i32 = (self.a.x() as i16 as i32) * (operand1 as i32);
 
         // Set carry and overflow if product wouldn't fit in i16
         if product < i16::MIN.into() || product > i16::MAX.into() {
@@ -318,8 +318,8 @@ impl Cpu {
             return false;
         }
 
-        let quotient = self.ax / operand1 as u16;
-        let remainder = self.ax % operand1 as u16;
+        let quotient = self.a.x() / operand1 as u16;
+        let remainder = self.a.x() % operand1 as u16;
 
         if quotient & 0xFF00 != 0 {
             return false;
@@ -339,7 +339,7 @@ impl Cpu {
             return false;
         }
 
-        let dividend = (self.dx as u32) << 16 | self.ax as u32;
+        let dividend = (self.d.x() as u32) << 16 | self.a.x() as u32;
 
         let quotient = dividend / operand1 as u32;
         let remainder = dividend % operand1 as u32;
@@ -362,7 +362,7 @@ impl Cpu {
             return false;
         }
 
-        let dividend = self.ax as i16;
+        let dividend = self.a.x() as i16;
 
         let quotient = dividend / operand1 as i8 as i16;
         let remainder = dividend % operand1 as i8 as i16;
@@ -387,7 +387,7 @@ impl Cpu {
             return false;
         }
 
-        let dividend: i32 = ((self.dx as u32) << 16 | self.ax as u32) as i32;
+        let dividend: i32 = ((self.d.x() as u32) << 16 | self.a.x() as u32) as i32;
 
         // Double cast to sign-extend operand properly
         let quotient = dividend / operand1 as i16 as i32;
@@ -406,29 +406,23 @@ impl Cpu {
 
     /// Sign extend AL into AX
     pub fn sign_extend_al(&mut self) {
-        if self.al & 0x80 != 0 {
-            self.ah = 0xFF;
-            self.ax |= 0xFF00;
+        if self.a.l() & 0x80 != 0 {
+            self.a.set_h(0xFF);
         }
         else {
-            self.ah = 0x00;
-            self.ax &= 0x00FF;
+            self.a.set_h(0);
         }
     }
 
     /// Sign extend AX ito DX:AX
     pub fn sign_extend_ax(&mut self) {
         self.cycles(3);
-        if self.ax & 0x8000 == 0 {
-            self.dx = 0x0000;
-            self.dl = 0x00;
-            self.dh = 0x00;
+        if self.a.x() & 0x8000 == 0 {
+            self.d.set_x(0x0000);
         }
         else {
             self.cycle(); // Microcode jump @ 05a
-            self.dx = 0xFFFF;
-            self.dl = 0xFF;
-            self.dh = 0xFF;
+            self.d.set_x(0xFFFF);
         }
     }
 

--- a/core/src/cpu_808x/bcd.rs
+++ b/core/src/cpu_808x/bcd.rs
@@ -38,22 +38,22 @@ impl Cpu {
     pub fn aaa(&mut self) {
         self.cycles_i(6, &[0x148, 0x149, 0x14a, 0x14b, 0x14c, 0x14d]);
 
-        let old_al = self.al;
+        let old_al = self.a.l();
         let new_al;
 
-        if ((self.al & 0x0F) > 9) || self.get_flag(Flag::AuxCarry) {
+        if ((self.a.l() & 0x0F) > 9) || self.get_flag(Flag::AuxCarry) {
             // Intel documentation shows AX := AX + 106 for AAA, but this does not lead to correct
             // behavior if AL carries to AH. Mistake on intel's part(?)
-            self.set_register8(Register8::AH, self.ah.wrapping_add(1));
-            new_al = self.al.wrapping_add(6);
+            self.set_register8(Register8::AH, self.a.h().wrapping_add(1));
+            new_al = self.a.l().wrapping_add(6);
             self.set_register8(Register8::AL, new_al & 0x0F);
             self.set_flag(Flag::AuxCarry);
             self.set_flag(Flag::Carry);
             //self.cycle_i(0x14e);
         }
         else {
-            new_al = self.al;
-            self.set_register8(Register8::AL, self.al & 0x0F);
+            new_al = self.a.l();
+            self.set_register8(Register8::AL, self.a.l() & 0x0F);
             self.clear_flag(Flag::AuxCarry);
             self.clear_flag(Flag::Carry);
             self.cycle_i(MC_JUMP);
@@ -79,24 +79,24 @@ impl Cpu {
     /// Ascii Adjust after Subtraction
     /// Flags: AuxCarry and Carry are set per operation. The OF, SF, ZF, and PF flags are undefined.
     pub fn aas(&mut self) {
-        let old_al = self.al;
+        let old_al = self.a.l();
         let old_af = self.get_flag(Flag::AuxCarry);
         let new_al;
 
         self.cycles_i(6, &[0x148, 0x149, 0x14a, 0x14b, MC_JUMP, 0x14d]);
-        if ((self.al & 0x0F) > 9) || old_af {
+        if ((self.a.l() & 0x0F) > 9) || old_af {
             // Intel documentation shows AX := AX - 6 for AAS, but the microcode only reads AL not AX
             // before calling XI.  Mistake on intel's part(?)
-            new_al = self.al.wrapping_sub(6);
-            self.set_register8(Register8::AH, self.ah.wrapping_sub(1));
+            new_al = self.a.l().wrapping_sub(6);
+            self.set_register8(Register8::AH, self.a.h().wrapping_sub(1));
             self.set_register8(Register8::AL, new_al & 0x0F);
             self.set_flag(Flag::AuxCarry);
             self.set_flag(Flag::Carry);
             //self.cycle_i(0x14e);
         }
         else {
-            new_al = self.al;
-            self.set_register8(Register8::AL, self.al & 0x0F);
+            new_al = self.a.l();
+            self.set_register8(Register8::AL, self.a.l() & 0x0F);
             self.clear_flag(Flag::Carry);
             self.clear_flag(Flag::AuxCarry);
             self.cycle_i(MC_JUMP);
@@ -126,17 +126,17 @@ impl Cpu {
     /// Flags: The SF, ZF, and PF flags are set according to the resulting binary value in the AL register
     pub fn aad(&mut self, imm8: u8) {
         self.cycles_i(3, &[0x170, 0x171, MC_JUMP]);
-        let product_native = (self.ah as u16).wrapping_mul(imm8 as u16) as u8;
-        let (_, product) = 0u8.corx(self, self.ah as u16, imm8 as u16, false);
+        let product_native = (self.a.h() as u16).wrapping_mul(imm8 as u16) as u8;
+        let (_, product) = 0u8.corx(self, self.a.h() as u16, imm8 as u16, false);
         assert!((product as u8) == product_native);
 
-        self.set_register8(Register8::AL, self.al.wrapping_add(product as u8));
+        self.set_register8(Register8::AL, self.a.l().wrapping_add(product as u8));
         self.set_register8(Register8::AH, 0);
 
         self.cycles_i(2, &[0x172, 0x173]);
 
         // Other sources set flags from AX register. Intel's documentation specifies AL
-        self.set_szp_flags_from_result_u8(self.al);
+        self.set_szp_flags_from_result_u8(self.a.l());
     }
 
     /// DAA — Decimal Adjust AL after Addition
@@ -146,7 +146,7 @@ impl Cpu {
     pub fn daa(&mut self) {
         let old_cf = self.get_flag(Flag::Carry);
         let old_af = self.get_flag(Flag::AuxCarry);
-        let old_al = self.al;
+        let old_al = self.a.l();
 
         self.clear_flag(Flag::Carry);
 
@@ -162,16 +162,16 @@ impl Cpu {
         // Handle undefined overflow flag behavior. Observed from testing against real cpu.
         self.clear_flag(Flag::Overflow);
         if old_cf {
-            if self.al >= 0x1a && self.al <= 0x7F {
+            if self.a.l() >= 0x1a && self.a.l() <= 0x7F {
                 self.set_flag(Flag::Overflow);
             }
         }
-        else if self.al >= 0x7a && self.al <= 0x7F {
+        else if self.a.l() >= 0x7a && self.a.l() <= 0x7F {
             self.set_flag(Flag::Overflow);
         }
 
-        if (self.al & 0x0F) > 9 || self.get_flag(Flag::AuxCarry) {
-            self.set_register8(Register8::AL, self.al.wrapping_add(6));
+        if (self.a.l() & 0x0F) > 9 || self.get_flag(Flag::AuxCarry) {
+            self.set_register8(Register8::AL, self.a.l().wrapping_add(6));
             self.set_flag(Flag::AuxCarry);
         }
         else {
@@ -179,20 +179,20 @@ impl Cpu {
         }
 
         if (old_al > al_check) || old_cf {
-            self.set_register8(Register8::AL, self.al.wrapping_add(0x60));
+            self.set_register8(Register8::AL, self.a.l().wrapping_add(0x60));
             self.set_flag(Flag::Carry);
         }
         else {
             self.clear_flag(Flag::Carry);
         }
 
-        self.set_szp_flags_from_result_u8(self.al);
+        self.set_szp_flags_from_result_u8(self.a.l());
     }
 
     /// DAS — Decimal Adjust AL after Subtraction
     /// Flags: The SF, ZF, and PF flags are set according to the result.
     pub fn das(&mut self) {
-        let old_al = self.al;
+        let old_al = self.a.l();
         let old_af = self.get_flag(Flag::AuxCarry);
         let old_cf = self.get_flag(Flag::Carry);
 
@@ -205,27 +205,27 @@ impl Cpu {
         self.clear_flag(Flag::Overflow);
 
         match (old_af, old_cf) {
-            (false, false) => match self.al {
+            (false, false) => match self.a.l() {
                 0x9A..=0xDF => self.set_flag(Flag::Overflow),
                 _ => {}
             },
-            (true, false) => match self.al {
+            (true, false) => match self.a.l() {
                 0x80..=0x85 | 0xA0..=0xE5 => self.set_flag(Flag::Overflow),
                 _ => {}
             },
-            (false, true) => match self.al {
+            (false, true) => match self.a.l() {
                 0x80..=0xDF => self.set_flag(Flag::Overflow),
                 _ => {}
             },
-            (true, true) => match self.al {
+            (true, true) => match self.a.l() {
                 0x80..=0xE5 => self.set_flag(Flag::Overflow),
                 _ => {}
             },
         }
 
         self.clear_flag(Flag::Carry);
-        if (self.al & 0x0F) > 9 || self.get_flag(Flag::AuxCarry) {
-            self.set_register8(Register8::AL, self.al.wrapping_sub(6));
+        if (self.a.l() & 0x0F) > 9 || self.get_flag(Flag::AuxCarry) {
+            self.set_register8(Register8::AL, self.a.l().wrapping_sub(6));
             self.set_flag(Flag::AuxCarry);
         }
         else {
@@ -233,14 +233,14 @@ impl Cpu {
         }
 
         if (old_al > al_check) || old_cf {
-            self.set_register8(Register8::AL, self.al.wrapping_sub(0x60) as u8);
+            self.set_register8(Register8::AL, self.a.l().wrapping_sub(0x60) as u8);
             self.set_flag(Flag::Carry);
         }
         else {
             self.clear_flag(Flag::Carry);
         }
 
-        self.set_szp_flags_from_result_u8(self.al);
+        self.set_szp_flags_from_result_u8(self.a.l());
     }
 
     /// AAM - Ascii adjust AX After multiply
@@ -252,14 +252,14 @@ impl Cpu {
         // 176: A->tmpc   | UNC CORD
         // Jump delay
 
-        match 0u8.cord(self, 0, imm8 as u16, self.al as u16) {
+        match 0u8.cord(self, 0, imm8 as u16, self.a.l() as u16) {
             Ok((quotient, remainder, _)) => {
                 // 177:          | COM1 tmpc
                 self.set_register8(Register8::AH, !(quotient as u8));
                 self.set_register8(Register8::AL, remainder as u8);
                 self.cycle_i(0x177);
                 // Other sources set flags from AX register. Intel's documentation specifies AL
-                self.set_szp_flags_from_result_u8(self.al);
+                self.set_szp_flags_from_result_u8(self.a.l());
                 return true;
             }
             Err(_) => return false,

--- a/core/src/cpu_808x/bitwise.rs
+++ b/core/src/cpu_808x/bitwise.rs
@@ -295,7 +295,7 @@ impl Cpu {
                 result = 0xFF;
             }
             Mnemonic::SETMOC => {
-                if self.cl != 0 {
+                if self.c.l() != 0 {
                     self.clear_flag(Flag::Carry);
                     self.clear_flag(Flag::AuxCarry);
                     self.clear_flag(Flag::Zero);
@@ -447,7 +447,7 @@ impl Cpu {
                 result = 0xFFFF;
             }
             Mnemonic::SETMOC => {
-                if self.cl != 0 {
+                if self.c.l() != 0 {
                     self.clear_flag(Flag::Carry);
                     self.clear_flag(Flag::AuxCarry);
                     self.clear_flag(Flag::Zero);

--- a/core/src/cpu_808x/execute.rs
+++ b/core/src/cpu_808x/execute.rs
@@ -602,7 +602,7 @@ impl Cpu {
                 // Cycles: 3 (1 Fetch + 2 EU)
                 // Flags: None
                 let op_reg = REGISTER16_LUT[(self.i.opcode & 0x07) as usize];
-                let ax_value = self.ax;
+                let ax_value = self.a.x();
                 let op_reg_value = self.get_register16(op_reg);
 
                 self.cycles_nx_i(2, &[0x084, 0x085]);
@@ -666,7 +666,7 @@ impl Cpu {
             }
             0x9E => {
                 // SAHF - Store AH into Flags
-                self.store_flags(self.ah as u16);
+                self.store_flags(self.a.h() as u16);
             }
             0x9F => {
                 // LAHF - Load Status Flags into AH Register
@@ -690,13 +690,13 @@ impl Cpu {
             0xA2 => {
                 // MOV offset8, Al
                 // These MOV variants are unique in that they take a direct offset with no modr/m byte
-                let op2_value = self.al;
+                let op2_value = self.a.l();
                 self.write_operand8(self.i.operand1_type, self.i.segment_override, op2_value, ReadWriteFlag::RNI);
             }
             0xA3 => {
                 // MOV offset16, AX
                 // These MOV variants are unique in that they take a direct offset with no modr/m byte
-                let op2_value = self.ax;
+                let op2_value = self.a.x();
                 self.write_operand16(self.i.operand1_type, self.i.segment_override, op2_value, ReadWriteFlag::RNI);   
             }
             0xA4 | 0xA5 => {
@@ -722,7 +722,7 @@ impl Cpu {
                         else {
                             self.cycles_i(2, &[0x131, 0x132]);
 
-                            if self.cx == 0 {
+                            if self.c.x() == 0 {
                                 // Fall through to 133, RNI
                                 self.rep_end();
                             }
@@ -783,7 +783,7 @@ impl Cpu {
     
                             // Check for REP end condition #2 (CX==0)
                             self.cycle_i(0x12b);
-                            if self.cx == 0 {
+                            if self.c.x() == 0 {
                                 self.rep_end();
                                 // Next instruction is 1f4: RNI, so don't spend cycle
                             }                 
@@ -801,7 +801,7 @@ impl Cpu {
             0xA8 => {
                 // TEST al, imm8
                 // Flags: o..sz.pc
-                let op1_value = self.al;
+                let op1_value = self.a.l();
                 let op2_value = self.read_operand8(self.i.operand2_type, SegmentOverride::None).unwrap();
                 
                 self.math_op8(Mnemonic::TEST,  op1_value, op2_value);
@@ -809,7 +809,7 @@ impl Cpu {
             0xA9 => {
                 // TEST ax, imm16
                 // Flags: o..sz.pc
-                let op1_value = self.ax;
+                let op1_value = self.a.x();
                 let op2_value = self.read_operand16(self.i.operand2_type, SegmentOverride::None).unwrap();
                 
                 self.math_op16(Mnemonic::TEST,  op1_value, op2_value);
@@ -834,7 +834,7 @@ impl Cpu {
                         
                         self.cycle_i(0x1f0);
                         self.decrement_register16(Register16::CX); //1f0
-                        if self.cx == 0 {
+                        if self.c.x() == 0 {
                             self.rep_end();
                         }
                         else {
@@ -873,7 +873,7 @@ impl Cpu {
                         else {
                             self.cycle_i(0x132);
 
-                            if self.cx == 0 {
+                            if self.c.x() == 0 {
                                 // Fall through to 133/1f9, RNI
                                 self.rep_end();
                             }
@@ -1081,15 +1081,15 @@ impl Cpu {
                 self.cycles_i(6, &[0x08c, 0x08d, 0x08e, MC_JUMP, 0x090, 0x091]);
                 //self.cycles_i(5, &[0x08d, 0x08e, MC_JUMP, 0x090, 0x091]);
 
-                if self.cl > 0 {
-                    for _ in 0..(self.cl ) {
+                if self.c.l() > 0 {
+                    for _ in 0..(self.c.l() ) {
                         self.cycles_i(4, &[MC_JUMP, 0x08f, 0x090, 0x091]);
                     }
                 }
                 
                 // If there is a terminal write to M, don't process RNI on line 0x92
                 if let OperandType::AddressingMode(_) = self.i.operand1_type {
-                    //if self.cl != 0 {
+                    //if self.c.l() != 0 {
                         self.cycle_i(0x092);
                     //}
                 }
@@ -1106,8 +1106,8 @@ impl Cpu {
                 self.cycles_i(6, &[0x08c, 0x08d, 0x08e, MC_JUMP, 0x090, 0x091]);
                 //self.cycles_i(5, &[0x08d, 0x08e, MC_JUMP, 0x090, 0x091]);
 
-                if self.cl > 0 {
-                    for _ in 0..(self.cl ) {
+                if self.c.l() > 0 {
+                    for _ in 0..(self.c.l() ) {
                         self.cycles_i(4, &[MC_JUMP, 0x08f, 0x090, 0x091]);
                     }
                 }
@@ -1157,7 +1157,7 @@ impl Cpu {
                 
                 // Handle segment override, default DS
                 let segment = Cpu::segment_override(self.i.segment_override, Segment::DS);
-                let disp16: u16 = self.bx.wrapping_add(self.al as u16);
+                let disp16: u16 = self.b.x().wrapping_add(self.a.l() as u16);
                 
                 self.cycles_i(3, &[0x10c, 0x10d, 0x10e]);
 
@@ -1187,7 +1187,7 @@ impl Cpu {
 
                 let rel8 = self.read_operand8(self.i.operand1_type, self.i.segment_override).unwrap();
 
-                if self.cx != 0 && zero_condition {
+                if self.c.x() != 0 && zero_condition {
                     self.reljmp2(rel8 as i8 as i16, true);
                     jump = true;
                 }
@@ -1204,7 +1204,7 @@ impl Cpu {
 
                 let rel8 = self.read_operand8(self.i.operand1_type, self.i.segment_override).unwrap();
 
-                if self.cx != 0 {
+                if self.c.x() != 0 {
                     self.reljmp2(rel8 as i8 as i16, true);
                     jump = true;
                 }
@@ -1221,7 +1221,7 @@ impl Cpu {
 
                 self.cycle_i(0x13b);
 
-                if self.cx == 0 {
+                if self.c.x() == 0 {
                     self.reljmp2(rel8 as i8 as i16, true);
                     jump = true;
                 }
@@ -1460,27 +1460,27 @@ impl Cpu {
                         let op1_value = self.read_operand8(self.i.operand1_type, self.i.segment_override).unwrap();
                         
                         //self.multiply_u8(op1_value);
-                        let product = self.mul8(self.al, op1_value, false, negate);
+                        let product = self.mul8(self.a.l(), op1_value, false, negate);
                         self.set_register16(Register16::AX, product);
 
                         if let OperandType::Register8(_) = self.i.operand1_type {
                             self.cycle();
                         }
 
-                        self.set_szp_flags_from_result_u8(self.ah);
+                        self.set_szp_flags_from_result_u8(self.a.h());
                     }
                     Mnemonic::IMUL => {
                         let op1_value = self.read_operand8(self.i.operand1_type, self.i.segment_override).unwrap();
                         
                         //self.multiply_i8(op1_value as i8);
-                        let product = self.mul8(self.al, op1_value, true, negate);
+                        let product = self.mul8(self.a.l(), op1_value, true, negate);
                         self.set_register16(Register16::AX, product);
 
                         if let OperandType::Register8(_) = self.i.operand1_type {
                             self.cycle();
                         }
 
-                        self.set_szp_flags_from_result_u8(self.ah);
+                        self.set_szp_flags_from_result_u8(self.a.h());
                     }                    
                     Mnemonic::DIV => {
                         let op1_value = self.read_operand8(self.i.operand1_type, self.i.segment_override).unwrap();
@@ -1493,14 +1493,14 @@ impl Cpu {
                         }
                         */
                         
-                        match self.div8(self.ax, op1_value, false, negate) {
+                        match self.div8(self.a.x(), op1_value, false, negate) {
                             Ok((al, ah)) => {
                                 self.set_register8(Register8::AL, al); // Quotient in AL
                                 self.set_register8(Register8::AH, ah); // Remainder in AH
                             }
                             Err(_) => {
 
-                                self.set_szp_flags_from_result_u8(self.ah);
+                                self.set_szp_flags_from_result_u8(self.a.h());
                                 //self.set_flag(Flag::Zero);
                                 //self.clear_flag(Flag::Sign);
                                 self.clear_flag(Flag::AuxCarry);
@@ -1521,14 +1521,14 @@ impl Cpu {
                         }
                         */
 
-                        match self.div8(self.ax, op1_value, true, negate) {
+                        match self.div8(self.a.x(), op1_value, true, negate) {
                             Ok((al, ah)) => {
                                 self.set_register8(Register8::AL, al); // Quotient in AL
                                 self.set_register8(Register8::AH, ah); // Remainder in AH
                             }
                             Err(_) => {
 
-                                self.set_szp_flags_from_result_u8(self.ah);
+                                self.set_szp_flags_from_result_u8(self.a.h());
                                 //self.set_flag(Flag::Zero);
                                 //self.clear_flag(Flag::Sign);                                
                                 self.clear_flag(Flag::AuxCarry);
@@ -1583,7 +1583,7 @@ impl Cpu {
                         // Multiply handles writing to ax
                         //self.multiply_u16(op1_value);
 
-                        let (dx, ax) = self.mul16(self.ax, op1_value, false, negate);
+                        let (dx, ax) = self.mul16(self.a.x(), op1_value, false, negate);
 
                         if let OperandType::Register16(_) = self.i.operand1_type {
                             self.cycle();
@@ -1593,14 +1593,14 @@ impl Cpu {
                         self.set_register16(Register16::DX, dx);
                         self.set_register16(Register16::AX, ax);
 
-                        self.set_szp_flags_from_result_u16(self.dx);
+                        self.set_szp_flags_from_result_u16(self.d.x());
                     }
                     Mnemonic::IMUL => {
                         let op1_value = self.read_operand16(self.i.operand1_type, self.i.segment_override).unwrap();
                         // Multiply handles writing to dx:ax
                         //self.multiply_i16(op1_value as i16);
                          
-                        let (dx, ax) = self.mul16(self.ax, op1_value, true, negate);
+                        let (dx, ax) = self.mul16(self.a.x(), op1_value, true, negate);
 
                         if let OperandType::Register16(_) = self.i.operand1_type {
                             self.cycle();
@@ -1609,7 +1609,7 @@ impl Cpu {
                         self.set_register16(Register16::DX, dx);
                         self.set_register16(Register16::AX, ax);    
 
-                        self.set_szp_flags_from_result_u16(self.dx);                    
+                        self.set_szp_flags_from_result_u16(self.d.x());
                     }
                     Mnemonic::DIV => {
                         let op1_value = self.read_operand16(self.i.operand1_type, self.i.segment_override).unwrap();
@@ -1621,14 +1621,14 @@ impl Cpu {
                         }
                         */
 
-                        match self.div16(((self.dx as u32) << 16 ) | (self.ax as u32), op1_value, false, negate) {
+                        match self.div16(((self.d.x() as u32) << 16 ) | (self.a.x() as u32), op1_value, false, negate) {
                             Ok((quotient, remainder)) => {
                                 self.set_register16(Register16::AX, quotient); // Quotient in AX
                                 self.set_register16(Register16::DX, remainder); // Remainder in DX
                             }
                             Err(_) => {
 
-                                self.set_szp_flags_from_result_u8(self.ah);
+                                self.set_szp_flags_from_result_u8(self.a.h());
                                 //self.set_flag(Flag::Zero);
                                 //self.clear_flag(Flag::Sign);
                                 self.clear_flag(Flag::AuxCarry);
@@ -1650,14 +1650,14 @@ impl Cpu {
                         }
                         */
 
-                        match self.div16(((self.dx as u32) << 16 ) | (self.ax as u32), op1_value, true, negate) {
+                        match self.div16(((self.d.x() as u32) << 16 ) | (self.a.x() as u32), op1_value, true, negate) {
                             Ok((quotient, remainder)) => {
                                 self.set_register16(Register16::AX, quotient); // Quotient in AX
                                 self.set_register16(Register16::DX, remainder); // Remainder in DX
                             }
                             Err(_) => {
 
-                                self.set_szp_flags_from_result_u8(self.ah);
+                                self.set_szp_flags_from_result_u8(self.a.h());
                                 //self.set_flag(Flag::Zero);
                                 //self.clear_flag(Flag::Sign);
                                 self.clear_flag(Flag::AuxCarry);

--- a/core/src/cpu_808x/fuzzer.rs
+++ b/core/src/cpu_808x/fuzzer.rs
@@ -173,7 +173,7 @@ impl Cpu {
                 // Mask CL to 6 bits to shorten tests.
                 // This will still catch emulators that are masking CL to 5 bits.
 
-                self.cl = self.cl & 0x3F;
+                self.c.set_l(self.c.l() & 0x3F);
             }
             0xC0..=0xC3 | 0xC8..=0xCF => {
                 // RETN, RETF, INT[X], IRET

--- a/core/src/cpu_808x/interrupt.rs
+++ b/core/src/cpu_808x/interrupt.rs
@@ -45,7 +45,7 @@ impl Cpu {
     pub fn sw_interrupt(&mut self, interrupt: u8) {
         // Interrupt FC, emulator internal services.
         if self.enable_service_interrupt && interrupt == 0xFC {
-            match self.ah {
+            match self.a.h() {
                 0x01 => {
                     // TODO: Make triggering pit logging a separate service number. Just re-using this one
                     // out of laziness.
@@ -53,14 +53,14 @@ impl Cpu {
 
                     log::debug!(
                         "Received emulator trap interrupt: CS: {:04X} IP: {:04X}",
-                        self.bx,
-                        self.cx
+                        self.b.x(),
+                        self.c.x()
                     );
                     self.biu_suspend_fetch();
                     self.cycles(4);
 
-                    self.cs = self.bx;
-                    self.pc = self.cx;
+                    self.cs = self.b.x();
+                    self.pc = self.c.x();
 
                     // Set execution segments
                     self.ds = self.cs;
@@ -96,7 +96,7 @@ impl Cpu {
                 call_ip: new_ip,
                 itype: InterruptType::Software,
                 number: interrupt,
-                ah: self.ah,
+                ah: self.a.h(),
             },
             self.cs,
             self.ip(),
@@ -164,40 +164,40 @@ impl Cpu {
         match interrupt {
             0x10 => {
                 // Video Services
-                match self.ah {
+                match self.a.h() {
                     0x00 => {
                         log::trace!(
                             "CPU: Video Interrupt: {:02X} (AH:{:02X} Set video mode) Video Mode: {:02X}",
                             interrupt,
-                            self.ah,
-                            self.al
+                            self.a.h(),
+                            self.a.l()
                         );
                     }
                     0x01 => {
                         log::trace!(
                             "CPU: Video Interrupt: {:02X} (AH:{:02X} Set text-mode cursor shape: CH:{:02X}, CL:{:02X})",
                             interrupt,
-                            self.ah,
-                            self.ch,
-                            self.cl
+                            self.a.h(),
+                            self.c.h(),
+                            self.c.l()
                         );
                     }
                     0x02 => {
                         log::trace!("CPU: Video Interrupt: {:02X} (AH:{:02X} Set cursor position): Page:{:02X} Row:{:02X} Col:{:02X}",
-                            interrupt, self.ah, self.bh, self.dh, self.dl);
+                            interrupt, self.a.h(), self.b.h(), self.d.h(), self.d.l());
                     }
                     0x09 => {
                         log::trace!("CPU: Video Interrupt: {:02X} (AH:{:02X} Write character and attribute): Char:'{}' Page:{:02X} Color:{:02x} Ct:{:02}", 
-                            interrupt, self.ah, self.al as char, self.bh, self.bl, self.cx);
+                            interrupt, self.a.h(), self.a.l() as char, self.b.h(), self.b.l(), self.c.x());
                     }
                     0x10 => {
                         log::trace!(
                             "CPU: Video Interrupt: {:02X} (AH:{:02X} Write character): Char:'{}' Page:{:02X} Ct:{:02}",
                             interrupt,
-                            self.ah,
-                            self.al as char,
-                            self.bh,
-                            self.cx
+                            self.a.h(),
+                            self.a.l() as char,
+                            self.b.h(),
+                            self.c.x()
                         );
                     }
                     _ => {}
@@ -237,7 +237,7 @@ impl Cpu {
                 call_ip: new_ip,
                 itype,
                 number: vector,
-                ah: self.ah,
+                ah: self.a.h(),
             },
             self.cs,
             self.ip(),

--- a/core/src/cpu_808x/logging.rs
+++ b/core/src/cpu_808x/logging.rs
@@ -60,7 +60,10 @@ impl Cpu {
         instr_str.push_str(&format!("{:04x}:{:04x} {}\n", last_cs, last_ip, self.i));
         instr_str.push_str(&format!(
             "AX: {:04x} BX: {:04x} CX: {:04x} DX: {:04x}\n",
-            self.ax, self.bx, self.cx, self.dx
+            self.a.x(),
+            self.b.x(),
+            self.c.x(),
+            self.d.x()
         ));
         instr_str.push_str(&format!(
             "SP: {:04x} BP: {:04x} SI: {:04x} DI: {:04x}\n",

--- a/core/src/cpu_808x/mod.rs
+++ b/core/src/cpu_808x/mod.rs
@@ -174,7 +174,7 @@ pub const OPCODE_PREFIX_REP1: u32 = 0b_0001_0000_0000;
 pub const OPCODE_PREFIX_REP2: u32 = 0b_0010_0000_0000;
 
 // The parity flag is calculated from the lower 8 bits of an alu operation regardless
-// of the operand width.  Thefore it is trivial to precalculate a 8-bit parity table.
+// of the operand width.  It is trivial to precalculate an 8-bit parity table.
 pub const PARITY_TABLE: [bool; 256] = {
     let mut table = [false; 256];
     let mut index = 0;
@@ -574,7 +574,7 @@ impl Default for InterruptDescriptor {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Instruction {
     pub opcode: u8,
     pub flags: u32,

--- a/core/src/cpu_808x/mod.rs
+++ b/core/src/cpu_808x/mod.rs
@@ -189,6 +189,76 @@ pub const PARITY_TABLE: [bool; 256] = {
     table
 };
 
+#[repr(C)]
+#[derive(Copy, Clone, Default)]
+pub struct GeneralRegisterBytes {
+    pub l: u8,
+    pub h: u8,
+}
+
+#[repr(C)]
+pub union GeneralRegister {
+    b: GeneralRegisterBytes,
+    w: u16,
+}
+impl Default for GeneralRegister {
+    fn default() -> Self {
+        GeneralRegister { w: 0 }
+    }
+}
+
+impl GeneralRegister {
+    // Safety: It is safe to access fields of a union comprised of unsigned integer types.
+    #[inline(always)]
+    pub fn x(&self) -> u16 {
+        unsafe { self.w }
+    }
+    #[inline(always)]
+    pub fn set_x(&mut self, value: u16) {
+        self.w = value;
+    }
+    #[inline(always)]
+    pub fn incr_x(&mut self) {
+        self.w = unsafe { self.w.wrapping_add(1) };
+    }
+    #[inline(always)]
+    pub fn decr_x(&mut self) {
+        self.w = unsafe { self.w.wrapping_sub(1) };
+    }
+    #[inline(always)]
+    pub fn h(&self) -> u8 {
+        unsafe { self.b.h }
+    }
+    #[inline(always)]
+    pub fn set_h(&mut self, value: u8) {
+        self.b.h = value;
+    }
+    #[inline(always)]
+    pub fn incr_h(&mut self) {
+        self.b.h = unsafe { self.b.h.wrapping_add(1) };
+    }
+    #[inline(always)]
+    pub fn decr_h(&mut self) {
+        self.b.h = unsafe { self.b.h.wrapping_sub(1) };
+    }
+    #[inline(always)]
+    pub fn l(&self) -> u8 {
+        unsafe { self.b.l }
+    }
+    #[inline(always)]
+    pub fn set_l(&mut self, value: u8) {
+        self.b.l = value;
+    }
+    #[inline(always)]
+    pub fn incr_l(&mut self) {
+        self.b.l = unsafe { self.b.l.wrapping_add(1) };
+    }
+    #[inline(always)]
+    pub fn decr_l(&mut self) {
+        self.b.l = unsafe { self.b.l.wrapping_sub(1) };
+    }
+}
+
 pub const REGISTER16_LUT: [Register16; 8] = [
     Register16::AX,
     Register16::CX,
@@ -623,26 +693,18 @@ pub struct Cpu {
     cpu_type: CpuType,
     state:    CpuState,
 
-    ah:    u8,
-    al:    u8,
-    ax:    u16,
-    bh:    u8,
-    bl:    u8,
-    bx:    u16,
-    ch:    u8,
-    cl:    u8,
-    cx:    u16,
-    dh:    u8,
-    dl:    u8,
-    dx:    u16,
-    sp:    u16,
-    bp:    u16,
-    si:    u16,
-    di:    u16,
-    cs:    u16,
-    ds:    u16,
-    ss:    u16,
-    es:    u16,
+    a: GeneralRegister,
+    b: GeneralRegister,
+    c: GeneralRegister,
+    d: GeneralRegister,
+    sp: u16,
+    bp: u16,
+    si: u16,
+    di: u16,
+    cs: u16,
+    ds: u16,
+    ss: u16,
+    es: u16,
     //ip:    u16,
     flags: u16,
 
@@ -1485,24 +1547,24 @@ impl Cpu {
     #[inline]
     pub fn get_register8(&self, reg: Register8) -> u8 {
         match reg {
-            Register8::AH => self.ah,
-            Register8::AL => self.al,
-            Register8::BH => self.bh,
-            Register8::BL => self.bl,
-            Register8::CH => self.ch,
-            Register8::CL => self.cl,
-            Register8::DH => self.dh,
-            Register8::DL => self.dl,
+            Register8::AH => self.a.h(),
+            Register8::AL => self.a.l(),
+            Register8::BH => self.b.h(),
+            Register8::BL => self.b.l(),
+            Register8::CH => self.c.h(),
+            Register8::CL => self.c.l(),
+            Register8::DH => self.d.h(),
+            Register8::DL => self.d.l(),
         }
     }
 
     #[inline]
     pub fn get_register16(&self, reg: Register16) -> u16 {
         match reg {
-            Register16::AX => self.ax,
-            Register16::BX => self.bx,
-            Register16::CX => self.cx,
-            Register16::DX => self.dx,
+            Register16::AX => self.a.x(),
+            Register16::BX => self.b.x(),
+            Register16::CX => self.c.x(),
+            Register16::DX => self.d.x(),
             Register16::SP => self.sp,
             Register16::BP => self.bp,
             Register16::SI => self.si,
@@ -1521,70 +1583,29 @@ impl Cpu {
         self.flags
     }
 
-    // Sets one of the 8 bit registers.
-    // It's tempting to represent the H/X registers as a union, because they are one.
-    // However, in the exercise of this project I decided to avoid all unsafe code.
+    // Set one of the 8 bit registers.
     #[inline]
     pub fn set_register8(&mut self, reg: Register8, value: u8) {
         match reg {
-            Register8::AH => {
-                self.ah = value;
-                self.ax = self.ax & REGISTER_HI_MASK | ((value as u16) << 8);
-            }
-            Register8::AL => {
-                self.al = value;
-                self.ax = self.ax & REGISTER_LO_MASK | (value as u16)
-            }
-            Register8::BH => {
-                self.bh = value;
-                self.bx = self.bx & REGISTER_HI_MASK | ((value as u16) << 8);
-            }
-            Register8::BL => {
-                self.bl = value;
-                self.bx = self.bx & REGISTER_LO_MASK | (value as u16)
-            }
-            Register8::CH => {
-                self.ch = value;
-                self.cx = self.cx & REGISTER_HI_MASK | ((value as u16) << 8);
-            }
-            Register8::CL => {
-                self.cl = value;
-                self.cx = self.cx & REGISTER_LO_MASK | (value as u16)
-            }
-            Register8::DH => {
-                self.dh = value;
-                self.dx = self.dx & REGISTER_HI_MASK | ((value as u16) << 8);
-            }
-            Register8::DL => {
-                self.dl = value;
-                self.dx = self.dx & REGISTER_LO_MASK | (value as u16)
-            }
+            Register8::AH => self.a.set_h(value),
+            Register8::AL => self.a.set_l(value),
+            Register8::BH => self.b.set_h(value),
+            Register8::BL => self.b.set_l(value),
+            Register8::CH => self.c.set_h(value),
+            Register8::CL => self.c.set_l(value),
+            Register8::DH => self.d.set_h(value),
+            Register8::DL => self.d.set_l(value),
         }
     }
 
+    // Set one of the 16 bit registers.
     #[inline]
     pub fn set_register16(&mut self, reg: Register16, value: u16) {
         match reg {
-            Register16::AX => {
-                self.ax = value;
-                self.ah = (value >> 8) as u8;
-                self.al = (value & REGISTER_HI_MASK) as u8;
-            }
-            Register16::BX => {
-                self.bx = value;
-                self.bh = (value >> 8) as u8;
-                self.bl = (value & REGISTER_HI_MASK) as u8;
-            }
-            Register16::CX => {
-                self.cx = value;
-                self.ch = (value >> 8) as u8;
-                self.cl = (value & REGISTER_HI_MASK) as u8;
-            }
-            Register16::DX => {
-                self.dx = value;
-                self.dh = (value >> 8) as u8;
-                self.dl = (value & REGISTER_HI_MASK) as u8;
-            }
+            Register16::AX => self.a.set_x(value),
+            Register16::BX => self.b.set_x(value),
+            Register16::CX => self.c.set_x(value),
+            Register16::DX => self.d.set_x(value),
             Register16::SP => self.sp = value,
             Register16::BP => self.bp = value,
             Register16::SI => self.si = value,
@@ -1615,18 +1636,37 @@ impl Cpu {
         }
     }
 
+    #[inline]
     pub fn decrement_register8(&mut self, reg: Register8) {
-        // TODO: do this directly
-        let mut value = self.get_register8(reg);
-        value = value.wrapping_sub(1);
-        self.set_register8(reg, value);
+        match reg {
+            Register8::AH => self.a.decr_h(),
+            Register8::AL => self.a.decr_l(),
+            Register8::BH => self.b.decr_h(),
+            Register8::BL => self.b.decr_l(),
+            Register8::CH => self.c.decr_h(),
+            Register8::CL => self.c.decr_l(),
+            Register8::DH => self.d.decr_h(),
+            Register8::DL => self.d.decr_l(),
+        }
     }
 
+    #[inline]
     pub fn decrement_register16(&mut self, reg: Register16) {
-        // TODO: do this directly
-        let mut value = self.get_register16(reg);
-        value = value.wrapping_sub(1);
-        self.set_register16(reg, value);
+        match reg {
+            Register16::AX => self.a.decr_x(),
+            Register16::BX => self.b.decr_x(),
+            Register16::CX => self.c.decr_x(),
+            Register16::DX => self.d.decr_x(),
+            Register16::SP => self.sp = self.sp.wrapping_sub(1),
+            Register16::BP => self.bp = self.bp.wrapping_sub(1),
+            Register16::SI => self.si = self.si.wrapping_sub(1),
+            Register16::DI => self.di = self.di.wrapping_sub(1),
+            Register16::CS => self.cs = self.cs.wrapping_sub(1),
+            Register16::DS => self.ds = self.ds.wrapping_sub(1),
+            Register16::SS => self.ss = self.ss.wrapping_sub(1),
+            Register16::ES => self.es = self.es.wrapping_sub(1),
+            _ => {}
+        }
     }
 
     pub fn set_reset_vector(&mut self, reset_vector: CpuAddress) {
@@ -1646,18 +1686,18 @@ impl Cpu {
 
     pub fn get_state(&self) -> CpuRegisterState {
         CpuRegisterState {
-            ah:    self.ah,
-            al:    self.al,
-            ax:    self.ax,
-            bh:    self.bh,
-            bl:    self.bl,
-            bx:    self.bx,
-            ch:    self.ch,
-            cl:    self.cl,
-            cx:    self.cx,
-            dh:    self.dh,
-            dl:    self.dl,
-            dx:    self.dx,
+            ah:    self.a.h(),
+            al:    self.a.l(),
+            ax:    self.a.x(),
+            bh:    self.b.h(),
+            bl:    self.b.l(),
+            bx:    self.b.x(),
+            ch:    self.c.h(),
+            cl:    self.c.l(),
+            cx:    self.c.x(),
+            dh:    self.d.h(),
+            dl:    self.d.l(),
+            dx:    self.d.x(),
             sp:    self.sp,
             bp:    self.bp,
             si:    self.si,
@@ -1676,18 +1716,18 @@ impl Cpu {
     /// This is used to display the CPU state viewer window in the debug GUI.
     pub fn get_string_state(&self) -> CpuStringState {
         CpuStringState {
-            ah:   format!("{:02x}", self.ah),
-            al:   format!("{:02x}", self.al),
-            ax:   format!("{:04x}", self.ax),
-            bh:   format!("{:02x}", self.bh),
-            bl:   format!("{:02x}", self.bl),
-            bx:   format!("{:04x}", self.bx),
-            ch:   format!("{:02x}", self.ch),
-            cl:   format!("{:02x}", self.cl),
-            cx:   format!("{:04x}", self.cx),
-            dh:   format!("{:02x}", self.dh),
-            dl:   format!("{:02x}", self.dl),
-            dx:   format!("{:04x}", self.dx),
+            ah:   format!("{:02x}", self.a.h()),
+            al:   format!("{:02x}", self.a.l()),
+            ax:   format!("{:04x}", self.a.x()),
+            bh:   format!("{:02x}", self.b.h()),
+            bl:   format!("{:02x}", self.b.l()),
+            bx:   format!("{:04x}", self.b.x()),
+            ch:   format!("{:02x}", self.c.h()),
+            cl:   format!("{:02x}", self.c.l()),
+            cx:   format!("{:04x}", self.c.x()),
+            dh:   format!("{:02x}", self.d.h()),
+            dl:   format!("{:02x}", self.d.l()),
+            dx:   format!("{:04x}", self.d.x()),
             sp:   format!("{:04x}", self.sp),
             bp:   format!("{:04x}", self.bp),
             si:   format!("{:04x}", self.si),
@@ -1784,18 +1824,18 @@ impl Cpu {
             };
 
             let offset = match reg2 {
-                "ah" => self.ah as u16,
-                "al" => self.al as u16,
-                "ax" => self.ax,
-                "bh" => self.bh as u16,
-                "bl" => self.bl as u16,
-                "bx" => self.bx,
-                "ch" => self.ch as u16,
-                "cl" => self.cl as u16,
-                "cx" => self.cx,
-                "dh" => self.dh as u16,
-                "dl" => self.dl as u16,
-                "dx" => self.dx,
+                "ah" => self.a.h() as u16,
+                "al" => self.a.l() as u16,
+                "ax" => self.a.x(),
+                "bh" => self.b.h() as u16,
+                "bl" => self.b.l() as u16,
+                "bx" => self.b.x(),
+                "ch" => self.c.h() as u16,
+                "cl" => self.c.l() as u16,
+                "cx" => self.c.x(),
+                "dh" => self.d.h() as u16,
+                "dl" => self.d.l() as u16,
+                "dx" => self.d.x(),
                 "sp" => self.sp,
                 "bp" => self.bp,
                 "si" => self.si,
@@ -2104,24 +2144,6 @@ impl Cpu {
     #[inline]
     pub fn trace_instr(&mut self, instr: u16) {
         self.trace_instr = instr;
-    }
-
-    pub fn assert_state(&self) {
-        let ax_should = (self.ah as u16) << 8 | self.al as u16;
-        let bx_should = (self.bh as u16) << 8 | self.bl as u16;
-        let cx_should = (self.ch as u16) << 8 | self.cl as u16;
-        let dx_should = (self.dh as u16) << 8 | self.dl as u16;
-
-        assert_eq!(self.ax, ax_should);
-        assert_eq!(self.bx, bx_should);
-        assert_eq!(self.cx, cx_should);
-        assert_eq!(self.dx, dx_should);
-
-        let should_be_off = self.flags & !CPU_FLAGS_RESERVED_OFF;
-        assert_eq!(should_be_off, 0);
-
-        let should_be_set = self.flags & CPU_FLAGS_RESERVED_ON;
-        assert_eq!(should_be_set, CPU_FLAGS_RESERVED_ON);
     }
 
     pub fn dump_cs(&self, path: &Path) {

--- a/core/src/cpu_808x/stack.rs
+++ b/core/src/cpu_808x/stack.rs
@@ -58,10 +58,10 @@ impl Cpu {
         self.sp = self.sp.wrapping_sub(2);
 
         let data = match reg {
-            Register16::AX => self.ax,
-            Register16::BX => self.bx,
-            Register16::CX => self.cx,
-            Register16::DX => self.dx,
+            Register16::AX => self.a.x(),
+            Register16::BX => self.b.x(),
+            Register16::CX => self.c.x(),
+            Register16::DX => self.d.x(),
             Register16::SP => self.sp,
             Register16::BP => self.bp,
             Register16::SI => self.si,

--- a/core/src/cpu_808x/step.rs
+++ b/core/src/cpu_808x/step.rs
@@ -239,7 +239,7 @@ impl Cpu {
                         cs: last_cs,
                         ip: last_ip,
                         cycles: self.instr_cycle as u16,
-                        i: self.i,
+                        i: self.i.clone(),
                     });
                 }
                 self.instruction_count += 1;
@@ -261,7 +261,7 @@ impl Cpu {
                         cs: last_cs,
                         ip: last_ip,
                         cycles: self.instr_cycle as u16,
-                        i: self.i,
+                        i: self.i.clone(),
                     });
                 }
                 self.instruction_count += 1;
@@ -295,7 +295,7 @@ impl Cpu {
                         cs: last_cs,
                         ip: last_ip,
                         cycles: self.instr_cycle as u16,
-                        i: self.i,
+                        i: self.i.clone(),
                     });
                 }
                 self.instruction_count += 1;

--- a/core/src/cpu_808x/step.rs
+++ b/core/src/cpu_808x/step.rs
@@ -346,10 +346,6 @@ impl Cpu {
         // only valid for a single instruction execution.
         self.intr_pending = false;
 
-        // Check registers and flags for internal consistency.
-        #[cfg(debug_assertions)]
-        self.assert_state();
-
         step_result
     }
 

--- a/core/src/cpu_808x/string.rs
+++ b/core/src/cpu_808x/string.rs
@@ -48,7 +48,7 @@ impl Cpu {
                 // No flags affected
 
                 // Write AL to [es:di]
-                self.biu_write_u8(Segment::ES, self.di, self.al, ReadWriteFlag::Normal);
+                self.biu_write_u8(Segment::ES, self.di, self.a.l(), ReadWriteFlag::Normal);
 
                 match self.get_flag(Flag::Direction) {
                     false => {
@@ -66,7 +66,7 @@ impl Cpu {
                 // No flags affected
 
                 // Write AX to [es:di]
-                self.biu_write_u16(Segment::ES, self.di, self.ax, ReadWriteFlag::Normal);
+                self.biu_write_u16(Segment::ES, self.di, self.a.x(), ReadWriteFlag::Normal);
 
                 match self.get_flag(Flag::Direction) {
                     false => {
@@ -170,7 +170,7 @@ impl Cpu {
                 let data = self.biu_read_u8(Segment::ES, self.di);
                 self.cycles_i(3, &[0x126, 0x127, 0x128]);
 
-                let (result, carry, overflow, aux_carry) = Cpu::sub_u8(self.al, data, false);
+                let (result, carry, overflow, aux_carry) = Cpu::sub_u8(self.a.l(), data, false);
                 // Test operation behaves like CMP
                 self.set_flag_state(Flag::Carry, carry);
                 self.set_flag_state(Flag::Overflow, overflow);
@@ -197,7 +197,7 @@ impl Cpu {
                 let data = self.biu_read_u16(Segment::ES, self.di, ReadWriteFlag::Normal);
                 self.cycles_i(3, &[0x126, 0x127, 0x128]);
 
-                let (result, carry, overflow, aux_carry) = Cpu::sub_u16(self.ax, data, false);
+                let (result, carry, overflow, aux_carry) = Cpu::sub_u16(self.a.x(), data, false);
                 // Test operation behaves like CMP
                 self.set_flag_state(Flag::Carry, carry);
                 self.set_flag_state(Flag::Overflow, overflow);
@@ -301,7 +301,7 @@ impl Cpu {
 
             if self.in_rep {
                 // Rep-prefixed instruction is starting for the first time. Run the RPTS procedure.
-                if self.cx == 0 {
+                if self.c.x() == 0 {
                     self.cycles_i(4, &[MC_JUMP, 0x112, 0x113, 0x114]);
                     self.rep_end();
                     return false;

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -28,7 +28,7 @@
 
     This module defines all the parts that make up the virtual computer.
 
-    This module owns Cpu and thus Bus, and is reponsible for maintaining both
+    This module owns Cpu and thus Bus, and is responsible for maintaining both
     machine and CPU execution state and running the emulated machine by calling
     the appropriate methods on Bus.
 
@@ -629,6 +629,10 @@ impl Machine {
 
     pub fn get_event(&mut self) -> Option<MachineEvent> {
         self.events.pop()
+    }
+
+    pub fn get_cpu_factor(&mut self) -> ClockFactor {
+        self.cpu_factor
     }
 
     pub fn load_program(&mut self, program: &[u8], program_seg: u16, program_ofs: u16) -> Result<(), bool> {

--- a/core/src/machine.rs
+++ b/core/src/machine.rs
@@ -1187,7 +1187,7 @@ impl Machine {
             }
 
             // If we returned a step over target address, execution is paused, and step over was requested,
-            // then consume as many instructions as needed to get to to the 'next' instruction. This will
+            // then consume as many instructions as needed to get to the 'next' instruction. This will
             // skip over any CALL or interrupt encountered.
             if step_over {
                 if let Some(step_over_target) = step_over_target {
@@ -1202,7 +1202,7 @@ impl Machine {
                                     StepResult::Normal => cpu_cycles = step_cycles,
                                     StepResult::Call(_) => {
                                         cpu_cycles = step_cycles
-                                        // We are already stepping over a base CALL instruction, so ignore futher CALLS/interrupts.
+                                        // We are already stepping over a base CALL instruction, so ignore further CALLS/interrupts.
                                     }
                                     StepResult::BreakpointHit => {
                                         // We can hit an 'inner' breakpoint while stepping over. This is fine, and ends the step


### PR DESCRIPTION
This PR changes the general A/B/C/D registers a union type.  Benchmarking shows there is negligible difference under optimization but debug builds are faster.

The resulting code is simpler however, despite requiring unsafe for the first time in MartyPC.