### PR TITLE
Update Tandy 1000 HX machine

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -18,6 +18,8 @@ Next, make sure you have git installed. If you need to install it, you can use y
 * Clone the repository
     * Type `git clone https://github.com/dbalsom/martypc.git`
 * Type `cd martypc/install`
+* Make sure LIBCLANG_PATH is set 
+    * e.g.) Type `set LIBCLANG_PATH=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin`
 * Type `cargo run -r --features ega` (features may vary - see Cargo.toml for a list)
 
 ### Building for Linux

--- a/install/configs/machines/tandy1000.toml
+++ b/install/configs/machines/tandy1000.toml
@@ -59,12 +59,12 @@ type = "Tandy1000"
 rom_set = "tandy1000hx"
 speaker = true
 overlays = [
-    "pcxt_2_360k_floppies",
+    "pcxt_2_720k_floppies",
 ]
 
     [machine.memory]
     #conventional.size = 0x20000 # 128KB max. Install additional RAM via expansion cards
-    conventional.size = 0x20000
+    conventional.size = 0x40000 # Tandy 1000 HX came with 256kb RAM default
     conventional.wait_states = 0
 
     [machine.keyboard]


### PR DESCRIPTION
Tandy 1000 HX came with 256KB RAM without the expansion card (640KB max).  This update lets me boot the Tandy 1000HX 128KB ROM with DOS 2.11 built in.  HX also had a single 720KB 3.5 floppy so modified from 360KB floppy.

I had a problem building and updated the BUILDING.md file with what I had to do to get it to build.