### PR TITLE
Fix Github Actions using Rust nightly on Windows/MSYS2

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: Windows
 on:
   push:
     branches:
-      - version_0_2_0
+      - version_0_4_0_GHA
   pull_request:
 
 env:
@@ -31,20 +31,22 @@ jobs:
           update: true
           msystem: ${{ matrix.environment.msystem }}
           pacboy: >-
-            rust:p
+            toolchain:p
+
+      - name: Install nightly Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh
+          sh rustup-init.sh -y --default-host x86_64-pc-windows-gnu --default-toolchain nightly --profile complete
+          $USERPROFILE/.cargo/bin/cargo version
 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install nightly Rust
-        run: |
-          rustup toolchain install nightly
-          rustup default nightly
-
       - name: Cargo build
-        run: cargo build --profile release-lto --features use_winit,use_wgpu,devtools,sound,opl
+        run: |
+          $USERPROFILE/.cargo/bin/cargo build --profile release-lto --features use_winit,use_wgpu,devtools,sound,opl
 
       - name: Copy files into install dir
         run: cp LICENSE README.md CHANGELOG.md CREDITS.md target/release-lto/martypc install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,7 +3,7 @@ name: Windows
 on:
   push:
     branches:
-      - version_0_4_0_GHA
+      - version_0_4_0
   pull_request:
 
 env:


### PR DESCRIPTION
Two potential problems should be solved later:

1. When using rustup-init.sh to install Rust nightly, the host `x86_64-pc-windows-gnu` is speicified directly. Better to use variable from environment matrix `mingw-w64-x86_64`.
2. After Rust nightly installed, neither `export new PATH` nor `echo PATH >>$GITHUB_ENV` worked for MSYS2. The cargo command is called from its default location. Better to set the path of rust/cargo expicitly to prevent from possible change of default installation location.

The Linux and macOS workflows are untouched.
BTW, why we need to build using nightly?